### PR TITLE
Add GFPS embedded callbacks: AccountKey written / NDA ready + add Dei…

### DIFF
--- a/embedded/client/source/nearby_fp_client.c
+++ b/embedded/client/source/nearby_fp_client.c
@@ -848,6 +848,11 @@ static nearby_platform_status SetNonDiscoverableAdvertisement() {
   length += nearby_fp_AppendTxPower(advertisement + length,
                                     sizeof(advertisement) - length,
                                     nearby_platform_GetTxLevel());
+  NEARBY_TRACE(INFO, "advertisement data: %s", nearby_utils_ArrayToString(advertisement, length));
+  // Called when NDA advertisement is prepared and ready to emit.
+  if (client_callbacks && client_callbacks->on_nondiscoverable_advertisement_ready) {
+    client_callbacks->on_nondiscoverable_advertisement_ready(advertisement, length);
+  }
   return nearby_platform_SetAdvertisement(advertisement, length,
                                           kNoLargerThan250ms);
 }
@@ -966,6 +971,10 @@ static nearby_platform_status OnAccountKeyWrite(uint64_t peer_address,
     return kNearbyStatusOK;
   }
   RunPostPairingSteps(peer_address, &key_info);
+  // Called to inform the app when a peer writes an Account Key.
+  if (client_callbacks && client_callbacks->on_account_key_written) {
+    client_callbacks->on_account_key_written(peer_address, decrypted_request);
+  }
   return kNearbyStatusOK;
 }
 
@@ -1070,7 +1079,7 @@ static void OnPaired(uint64_t peer_address) {
   else if (AddRetroactivePairingPeer(peer_address) == false) {
     NEARBY_TRACE(WARNING, "No more timer for retroactive pairing");
   }
-#endif /* NEARBY_FP_RETROACTIVE_AIRING */
+#endif /* NEARBY_FP_RETROACTIVE_PAIRING */
 }
 
 static void OnPairingFailed(uint64_t peer_address) {
@@ -2013,4 +2022,12 @@ nearby_platform_status nearby_fp_client_Init(
   RotateBleAddress();
 
   return status;
+}
+
+nearby_platform_status nearby_fp_client_Deinit(void) {
+  client_callbacks = NULL;
+
+  // TODO: Add internal teardown logic here (BLE/Bluetooth/SE/Persistence/etc.)
+
+  return kNearbyStatusOK;
 }

--- a/embedded/client/source/nearby_fp_client.h
+++ b/embedded/client/source/nearby_fp_client.h
@@ -28,8 +28,23 @@ extern "C" {
 #endif /* __cplusplus */
 
 typedef struct {
-  // Optional event callback
+  // Optional generic event handler for all Fast Pair events.
+  // Payload type depends on the event_type.
   void (*on_event)(nearby_event_Event* event);
+
+  // Called when a remote peer successfully writes an Account Key during pairing.
+  // The Account Key has already been decrypted by the GFPS layer.
+  // Parameters:
+  //   peer_addr - BLE address of the remote device
+  //   key       - 16-byte decrypted Account Key
+  void (*on_account_key_written)(uint64_t peer_addr, const uint8_t key[16]);
+
+  // Called when the GFPS layer finishes constructing a Non-Discoverable Advertisement (NDA).
+  // The application layer is responsible for sending the advertisement payload.
+  // Parameters:
+  //   adv_data - pointer to raw advertisement data
+  //   len      - length of the advertisement in bytes
+  void (*on_nondiscoverable_advertisement_ready)(const uint8_t* adv_data, size_t len);
 } nearby_fp_client_Callbacks;
 
 // Seeker information structure
@@ -72,6 +87,9 @@ nearby_platform_status nearby_fp_client_SetAdvertisement(int mode);
 // Initalizes Fast Pair provider. The |callbacks| are optional - can be NULL.
 nearby_platform_status nearby_fp_client_Init(
     const nearby_fp_client_Callbacks* callbacks);
+
+// Releases internal Fast Pair resources and resets callback bindings.
+nearby_platform_status nearby_fp_client_Deinit(void);
 
 #if NEARBY_FP_MESSAGE_STREAM
 // Serializes and sends |message| over Message Stream


### PR DESCRIPTION
…nit()

(cherry picked from commit 175a88de0003297d1a40ebdb2e78f48afc639fe6)

<!--- Provide a general summary of your changes in the Title above -->

Add GFPS callback hooks for NDA and AccountKey events + client teardown support

<!--- Describe your changes in detail -->

### Summary
This base complies with the original espp-v1.0.12.
This change was rebased from commit 175a88d to align with the espp-main history.

This change introduces two embedded-layer callback hooks for GFPS client logic:

- `on_account_key_written` — triggers on peer Account Key writes
- `on_nondiscoverable_advertisement_ready` — triggers when NDA payload is generated

Also adds `nearby_fp_client_Deinit()` for embedded lifecycle support.
This enables app-layer integration via callback delegation as outlined in esp-cpp/espp#466. 

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In Fast Pair flow, writing an Account Key is a critical indication that the connecting peer is a Fast Pair–capable device. Without observing this write event, the embedded layer cannot reliably distinguish a standard Bluetooth connection from a Fast Pair session.

This callback provides the application layer with context to associate the Account Key write with device metadata (e.g., name, address). That association allows the app to decide—after a reboot or power cycle—whether to continue emitting Non-Discoverable Advertisements (NDA) for seamless reconnection.

While maintaining NDA state alone could partially cover this use case, explicit correlation with Account Key events improves clarity and resilience in lifecycle handling.

All changes are additive and designed to be opt-in. Existing flows are unaffected unless the new callbacks are explicitly registered.

>  Note: During merge with `upstream/main`, the `embedded/client` folder was deleted in the base branch. This PR retains `nearby_fp_client.c/h` to preserve embedded callback integration as required by espp#466.

### How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Verified in integration with esp-cpp/espp:

- NDA payload dispatch confirmed via logging
- Account Key write path invoked from simulated pairing flow
- Deinit stub reachable from `gfps_service::reset()` teardown logic

Tested using `esp-idf` build environment with logging level `INFO`.
Confirmed compatibility with callback wiring in `gfps_service::Init()` and `Config` registration path.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software

<!-- Delete this section if not relevant to your PR  -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
